### PR TITLE
Replace Windows separators function

### DIFF
--- a/src/core/Media.cpp
+++ b/src/core/Media.cpp
@@ -17,6 +17,7 @@
 *****************************************************************************/
 
 #include <QtCore/QDebug>
+#include <QtCore/QDir>
 
 #include <vlc/vlc.h>
 
@@ -67,10 +68,8 @@ void VlcMedia::initMedia(const QString &location,
 {
     _currentLocation = location;
     QString l = location;
-#if defined(Q_OS_WIN32)
     if (localFile)
-        l.replace("/", "\\");
-#endif
+        l = QDir::toNativeSeparators(l);
 
     // Create a new libvlc media descriptor from location
     if (localFile)
@@ -155,10 +154,7 @@ QString VlcMedia::merge(const QString &name,
                         const Vlc::Mux &mux)
 {
     QString option1, option2, parameters;
-    QString l = path + "/" + name;
-#if defined(Q_OS_WIN32)
-    l.replace("/", "\\");
-#endif
+    QString l = QDir::toNativeSeparators(path + "/" + name);
 
     parameters = "gather:std{access=file,mux=%1,dst='%2'}";
     parameters = parameters.arg(Vlc::mux()[mux], l + "." + Vlc::mux()[mux]);


### PR DESCRIPTION
Path separators should be adapted using Qt function toNativeSeparators(). It also provides safety and flexibility for
future. Got no Qt nearby, code needs to be tested.
