### PR TITLE
Vlc -> Qml issue fixed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ IF(MINGW OR MSVC)
 ENDIF(MINGW OR MSVC)
 
 # Link parameters
-IF(STATIC)
+IF(STATIC AND NOT MSVC)
     SET(VLCQT_BINARY ${CMAKE_BINARY_DIR}/src/core/libvlc-qt.a)
     SET(VLCQT_WIDGETS_BINARY ${CMAKE_BINARY_DIR}/src/widgets/libvlc-qt-widgets.a)
     SET(VLCQT_QML_BINARY ${CMAKE_BINARY_DIR}/src/qml/libvlc-qt-qml.a)
@@ -161,6 +161,7 @@ ELSEIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     SET(VLCQT_WIDGETS_BINARY ${CMAKE_BINARY_DIR}/src/widgets/libvlc-qt-widgets.dylib)
     SET(VLCQT_QML_BINARY ${CMAKE_BINARY_DIR}/src/qml/libvlc-qt-qml.dylib)
 ELSEIF(MSVC)
+    MESSAGE("MSVC linking")
     SET(VLCQT_BINARY ${CMAKE_BINARY_DIR}/src/core/vlc-qt.lib)
     SET(VLCQT_WIDGETS_BINARY ${CMAKE_BINARY_DIR}/src/widgets/vlc-qt-widgets.lib)
     SET(VLCQT_QML_BINARY ${CMAKE_BINARY_DIR}/src/qml/vlc-qt-qml.lib)
@@ -168,7 +169,7 @@ ELSE(STATIC)
     SET(VLCQT_BINARY ${CMAKE_BINARY_DIR}/src/core/libvlc-qt.so)
     SET(VLCQT_WIDGETS_BINARY ${CMAKE_BINARY_DIR}/src/widgets/libvlc-qt-widgets.so)
     SET(VLCQT_QML_BINARY ${CMAKE_BINARY_DIR}/src/qml/libvlc-qt-qml.so)
-ENDIF(STATIC)
+ENDIF(STATIC AND NOT MSVC)
 
 
 ###########

--- a/src/qml/QmlVideoObject.cpp
+++ b/src/qml/QmlVideoObject.cpp
@@ -33,7 +33,7 @@ VlcQmlVideoObject::VlcQmlVideoObject(QQuickItem *parent)
       _paintedOnce(false),
       _gotSize(false)
 {
-    setRenderTarget(InvertedYFramebufferObject);
+	setRenderTarget(InvertedYFramebufferObject);
     setFlag(ItemHasContents, true);
 }
 

--- a/src/qml/QmlVideoPlayer.h
+++ b/src/qml/QmlVideoPlayer.h
@@ -47,11 +47,11 @@ public:
 private:
 	void openInternal();
 
-	VlcInstance *_instance;
-	VlcMediaPlayer *_player;
-	VlcMedia *_media;
+	VlcInstance *_instance = nullptr;
+	VlcMediaPlayer *_player = nullptr;
+	VlcMedia *_media = nullptr;
 
-	VlcAudio *_audioManager;
+	VlcAudio *_audioManager = nullptr;
 
 	bool _hasMedia;
 };

--- a/src/qml/painter/GlslPainter.cpp
+++ b/src/qml/painter/GlslPainter.cpp
@@ -132,17 +132,16 @@ void GlslPainter::paint(QPainter *painter,
         1, 0, // top right
     };
 
-    const GLfloat targetVertex[] =
+	const GLfloat targetVertex[] =
     {
-        GLfloat(target.left()), GLfloat(target.bottom()),
-        GLfloat(target.right()), GLfloat(target.bottom()),
-        GLfloat(target.left()) , GLfloat(target.top()),
-        GLfloat(target.right()), GLfloat(target.top())
+        GLfloat(0), GLfloat(target.height()),
+		GLfloat(target.width()), GLfloat(target.height()),
+        GLfloat(0) , GLfloat(0),
+		GLfloat(target.width()), GLfloat(0)
     };
-    //
 
-    const int width = window->width();
-    const int height = window->height();
+    const int width = target.width();
+    const int height = target.height();
 
     const QTransform transform = painter->deviceTransform();
 

--- a/tests/test-qml/main.cpp
+++ b/tests/test-qml/main.cpp
@@ -24,18 +24,19 @@
 
 int main(int argc, char *argv[])
 {
-    QCoreApplication::setApplicationName("Test QML");
-    QCoreApplication::setAttribute(Qt::AA_X11InitThreads);
+	QCoreApplication::setApplicationName("Test QML");
+	QCoreApplication::setAttribute(Qt::AA_X11InitThreads);
 
-    qmlRegisterType<VlcQmlVideoPlayer>("VLCQt", 0, 9, "VlcVideoPlayer");
+	qmlRegisterType<VlcQmlVideoPlayer>("VLCQt", 0, 9, "VlcVideoPlayer");
 
-    QGuiApplication app(argc, argv);
+	QGuiApplication app(argc, argv);
 
-    QQuickView view;;
-    view.setSource(QUrl("qml/video.qml"));
-    view.setResizeMode(QQuickView::SizeRootObjectToView);
-    view.show();
+	QQuickView view;;
+	view.setSource(QUrl("qml/video.qml"));
+	//view.setResizeMode(QQuickView::SizeRootObjectToView);
+	view.setMinimumWidth(640); view.setMinimumHeight(480);
+	view.show();
 
-    return app.exec();
+	return app.exec();
 }
 

--- a/tests/test-qml/qml/video.qml
+++ b/tests/test-qml/qml/video.qml
@@ -31,7 +31,7 @@ Rectangle {
         MouseArea {
             anchors.fill: parent
             onClicked: {
-                vidwidget.openFile("/Users/tadej/Movies/Yugo.mpeg")
+                vidwidget.openStream("http://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4")
                 vidwidget.play()
             }
         }

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -73,10 +73,10 @@ SET(Qt5_Libs
 
 FILE(GLOB Qt5_Libs_Icu ${QT_BIN_DIR}/icu*.dll)
 
-SET(Qt5_Libs_Gui
-    ${QT_BIN_DIR}/libEGL${LE}.dll
-    ${QT_BIN_DIR}/libGLESv2${LE}.dll
-)
+# SET(Qt5_Libs_Gui
+#     ${QT_BIN_DIR}/libEGL${LE}.dll
+#     ${QT_BIN_DIR}/libGLESv2${LE}.dll
+# )
 
 FILE(GLOB Qt5_Libs_D3D ${QT_BIN_DIR}/D3DCompiler_*.dll)
 
@@ -89,7 +89,7 @@ SET(Qt5_Libs_Qml
     ${QT_BIN_DIR}/Qt5OpenGL${LE}.dll
     ${QT_BIN_DIR}/Qt5Qml${LE}.dll
     ${QT_BIN_DIR}/Qt5Quick${LE}.dll
-    ${QT_BIN_DIR}/Qt5V8${LE}.dll
+    # ${QT_BIN_DIR}/Qt5V8${LE}.dll
 )
 
 SET(Vlc_Libs


### PR DESCRIPTION
The QML component of vlc-qt didn't scale as expected. 

Symptoms:
If you had multiple items in a window, multiple rectangles for instance, and had the video playing in one of the rectangles, the video would not actually fill that rectangle. 
Also, re-sizing the window changed the size of the video even though the parent rectangle of the video didn't necessarily change.