### PR TITLE
VC++ compiler does not init field values with 0.

### DIFF
--- a/src/qml/QmlVideoPlayer.cpp
+++ b/src/qml/QmlVideoPlayer.cpp
@@ -28,7 +28,8 @@
 
 VlcQmlVideoPlayer::VlcQmlVideoPlayer(QQuickItem *parent)
     : VlcQmlVideoObject(parent),
-      _hasMedia(false)
+      _hasMedia(false),
+      _media(0)
 {
     _instance = new VlcInstance(VlcCommon::args(), this);
     _player = new VlcMediaPlayer(_instance);


### PR DESCRIPTION
In this case usual value of address either 0xcdcdcdcd (Win32) of 0xcdcdcdcdcdcdcdcd (Win64). And in open\* methods deleting such _media object will cause access violation.
