### PR TITLE
[qml] Fix sample aspect ratio

### DIFF
--- a/src/core/MediaPlayer.cpp
+++ b/src/core/MediaPlayer.cpp
@@ -398,6 +398,34 @@ float VlcMediaPlayer::position()
     return libvlc_media_player_get_position(_vlcMediaPlayer);
 }
 
+float VlcMediaPlayer::sampleAspectRatio()
+{
+    if(!_vlcMediaPlayer)
+        return 0.0;
+
+    float sar = 0.0;
+
+    libvlc_media_track_t **tracks;
+    unsigned tracksCount;
+    tracksCount = libvlc_media_tracks_get( _media->core(), &tracks );
+    if( tracksCount > 0 )
+    {
+        for( int i = 0; i < tracksCount; i++ )
+        {
+            libvlc_media_track_t *track = tracks[i];
+            if( track->i_type == libvlc_track_video && track->i_id == 0 )
+            {
+                libvlc_video_track_t *videoTrack = track->video;
+                if( videoTrack->i_sar_num > 0 )
+                    sar = (float)videoTrack->i_sar_den / (float)videoTrack->i_sar_num;
+            }
+        }
+        libvlc_media_tracks_release( tracks, tracksCount );
+    }
+
+    return sar;
+}
+
 void VlcMediaPlayer::setPosition(float pos)
 {
     libvlc_media_player_set_position(_vlcMediaPlayer, pos);

--- a/src/core/MediaPlayer.cpp
+++ b/src/core/MediaPlayer.cpp
@@ -402,7 +402,7 @@ float VlcMediaPlayer::sampleAspectRatio()
 {
     if(!_vlcMediaPlayer)
         return 0.0;
-
+#if LIBVLC_VERSION >= 0x020100
     float sar = 0.0;
 
     libvlc_media_track_t **tracks;
@@ -424,6 +424,9 @@ float VlcMediaPlayer::sampleAspectRatio()
     }
 
     return sar;
+#else
+    return 1.0;
+#endif // LIBVLC_VERSION >= 0x020100
 }
 
 void VlcMediaPlayer::setPosition(float pos)

--- a/src/core/MediaPlayer.h
+++ b/src/core/MediaPlayer.h
@@ -171,7 +171,7 @@ public:
     float position();
 
     /*!
-        \brief Get sample aspect ratio for current video track.
+        \brief Get sample aspect ratio for current video track( vlc >= 2.1.0 ).
         \return sample aspect ratio (float)
     */
     float sampleAspectRatio();

--- a/src/core/MediaPlayer.h
+++ b/src/core/MediaPlayer.h
@@ -170,6 +170,12 @@ public:
     */
     float position();
 
+    /*!
+        \brief Get sample aspect ratio for current video track.
+        \return sample aspect ratio (float)
+    */
+    float sampleAspectRatio();
+
 public slots:
     /*! \brief Set the movie position.
 

--- a/src/qml/QmlVideoObject.cpp
+++ b/src/qml/QmlVideoObject.cpp
@@ -26,6 +26,7 @@
 
 VlcQmlVideoObject::VlcQmlVideoObject(QQuickItem *parent)
     : QQuickPaintedItem(parent),
+      _player(0),
       _geometry(0, 0, 640, 480),
       _boundingRect(0, 0, 0, 0),
       _frameSize(0, 0),
@@ -232,6 +233,15 @@ void VlcQmlVideoObject::unlockCallback(void *picture, void *const*planes)
 
 void VlcQmlVideoObject::displayCallback(void *picture)
 {
+    if( !_frame.inited )
+    {
+        float sar = _player->sampleAspectRatio();
+        if( sar > 0.0 )
+        {
+            _frame.height *= sar;
+            _frame.inited = true;
+        }
+    }
     Q_UNUSED(picture); // There is only one buffer.
 }
 
@@ -269,8 +279,6 @@ unsigned int VlcQmlVideoObject::formatCallback(char *chroma,
         _frame.lines[i] = lines[i];
         _frame.plane[i].resize(pitches[i] * lines[i]);
     }
-
-    _frame.inited = true;
 
     return bufferSize;
 }

--- a/src/qml/QmlVideoObject.h
+++ b/src/qml/QmlVideoObject.h
@@ -96,7 +96,8 @@ public:
      */
     void setCropRatio(const Vlc::Ratio &cropRatio);
 
-
+protected:
+    VlcMediaPlayer *_player;
 private slots:
     void frameReady();
     void reset();

--- a/src/qml/QmlVideoPlayer.cpp
+++ b/src/qml/QmlVideoPlayer.cpp
@@ -150,10 +150,10 @@ QUrl VlcQmlVideoPlayer::url() const
 
 void VlcQmlVideoPlayer::setUrl(const QUrl &url)
 {
+    _player->stop();
+
     if (_media)
         delete _media;
-
-    _player->stop();
 
     if(url.isLocalFile()) {
         _media = new VlcMedia(url.toLocalFile(), true, _instance);

--- a/src/qml/QmlVideoPlayer.cpp
+++ b/src/qml/QmlVideoPlayer.cpp
@@ -31,7 +31,6 @@
 VlcQmlVideoPlayer::VlcQmlVideoPlayer(QQuickItem *parent)
     : VlcQmlVideoObject(parent),
       _instance(0),
-      _player(0),
       _media(0),
       _audioManager(0),
       _deinterlacing(Vlc::Disabled),
@@ -153,6 +152,8 @@ void VlcQmlVideoPlayer::setUrl(const QUrl &url)
 {
     if (_media)
         delete _media;
+
+    _player->stop();
 
     if(url.isLocalFile()) {
         _media = new VlcMedia(url.toLocalFile(), true, _instance);

--- a/src/qml/QmlVideoPlayer.h
+++ b/src/qml/QmlVideoPlayer.h
@@ -345,7 +345,6 @@ private:
     void openInternal();
 
     VlcInstance *_instance;
-    VlcMediaPlayer *_player;
     VlcMedia *_media;
 
     VlcAudio *_audioManager;


### PR DESCRIPTION
Libvlc does not fix frame with sample aspect ratio and it does not provide simple way to get it value when we use *vmem* module( for qml ). I found that it can be got from *libvlc_media_track_t* structure but *sar* field takes value after some event that i cant determine. 
Other issue is getting right video track from *libvlc_media_track_t* structure. There is not current video track id( *libvlc_video_get_track* ) in *libvlc_media_track_t*. This is why i always use video track with 0 id.