### PR TITLE
Made setMute() a slot again

### DIFF
--- a/src/core/Audio.h
+++ b/src/core/Audio.h
@@ -88,14 +88,14 @@ public slots:
     */
     void setChannel(Vlc::AudioChannel channel);
 
-
-public:
     /*!
         \brief Set mute state.
         \param mute mute state (bool)
     */
     void setMute(bool mute) const;
 
+
+public:
     /*!
         \brief Get current audio track.
         \return the number of current audio track, or -1 if none (const int)


### PR DESCRIPTION
setVolume(), setTrack(), setChannel() and even toggleMute() are all slots. I would suggest making setMute() a slot also. You can connect it to a checkable button that way.