### PR TITLE
Added VLCQT_QML_EXPORT maco on class

### DIFF
--- a/src/qml/QmlPlayer.h
+++ b/src/qml/QmlPlayer.h
@@ -41,7 +41,7 @@ class VlcTrackModel;
     \see VlcQmlVideoOutput
     \since VLC-Qt 1.1
  */
-class VlcQmlPlayer : public VlcQmlSource
+class VLCQT_QML_EXPORT VlcQmlPlayer : public VlcQmlSource
 {
     Q_OBJECT
 


### PR DESCRIPTION
Without this macro, the project cannot be linked against.  (`registerTypes` attempts to register `VlcQmlPlayer`, which wouldn't be exposed in the DLL.)  See #173