### PR TITLE
VlcMedia ctor (libvlc_media_t* based) fix 

### DIFF
--- a/src/core/Media.cpp
+++ b/src/core/Media.cpp
@@ -46,6 +46,10 @@ VlcMedia::VlcMedia(libvlc_media_t *media)
     // Create a new libvlc media descriptor from existing one
     _vlcMedia = libvlc_media_duplicate(media);
 
+    _vlcEvents = libvlc_media_event_manager(_vlcMedia);
+
+    createCoreConnections();
+
     VlcError::showErrmsg();
 }
 


### PR DESCRIPTION
faced with an issue in case of using custom Media with manually created libvlc_media_t* (this created by callbacks - new vlc 3.0 functionality to play back a streams from a memory) .
segmentation fault (Ubuntu 16.04, Qt 5.9.1, latest git vlc-qt) on the destruction of VlcMedia.
traced the calls and found that attempt to unsibscribe of the events causes this problem.
as far as I see there is no events subscribing in a constructor with libvlc_media_t* parameter.
so I've added events registration to this constructor, similar like in other one, and issue was fixed to me.

please review