### PR TITLE
QmlVideoOutput: Respect SAR

### DIFF
--- a/src/core/VideoStream.h
+++ b/src/core/VideoStream.h
@@ -84,6 +84,11 @@ public:
      */
     std::shared_ptr<const VlcAbstractVideoFrame> renderFrame() const { return _renderFrame; } // LCOV_EXCL_LINE
 
+    /*!
+        \brief Get the current player
+        \return current player
+     */
+    VlcMediaPlayer *player() const { return _player; }
 private:
     Q_INVOKABLE virtual void frameUpdated() = 0;
 

--- a/src/qml/QmlSource.cpp
+++ b/src/qml/QmlSource.cpp
@@ -33,6 +33,11 @@ void VlcQmlSource::setPlayer(VlcMediaPlayer *player)
     _videoStream->init(player);
 }
 
+VlcMediaPlayer *VlcQmlSource::player() const
+{
+    return _videoStream->player();
+}
+
 void VlcQmlSource::removePlayer()
 {
     _videoStream->deinit();

--- a/src/qml/QmlSource.h
+++ b/src/qml/QmlSource.h
@@ -67,6 +67,12 @@ public:
     void removePlayer();
 
     /*!
+        \brief Get the current player
+        \return current player
+    */
+    VlcMediaPlayer *player() const;
+
+    /*!
         \brief Register video output
         \param output QML video output
      */

--- a/src/qml/QmlVideoOutput.cpp
+++ b/src/qml/QmlVideoOutput.cpp
@@ -19,6 +19,7 @@
 #include "core/YUVVideoFrame.h"
 #include "qml/QmlSource.h"
 #include "qml/QmlVideoOutput.h"
+#include "core/MediaPlayer.h"
 #include "qml/rendering/VideoNode.h"
 
 VlcQmlVideoOutput::VlcQmlVideoOutput()
@@ -124,8 +125,10 @@ QSGNode *VlcQmlVideoOutput::updatePaintNode(QSGNode *oldNode,
     QRectF srcRect(0, 0, 1., 1.);
 
     if (fillMode() != Vlc::Stretch) {
+        float sar = _source->player()->sampleAspectRatio();
+        if (sar <= 0) sar = 1;
         const uint16_t fw = _frame->width;
-        const uint16_t fh = _frame->height;
+        const uint16_t fh = _frame->height * sar;
 
         qreal frameAspectTmp = qreal(fw) / fh;
         QSizeF aspectRatioSize = Vlc::ratioSize(_aspectRatio);


### PR DESCRIPTION
The new QML classes did not respect the storage aspect ratio of the video, resulting in wrong aspect ratio.